### PR TITLE
Patch_sampling possible w/ mask_level > max_level

### DIFF
--- a/useful_wsi/patch_sampling.py
+++ b/useful_wsi/patch_sampling.py
@@ -8,7 +8,7 @@ import itertools
 import numpy as np
 
 from .tissue_segmentation import roi_binary_mask
-from .utils import (find_square, get_size, get_whole_image, pj_slice,
+from .utils import (find_square, get_size, get_whole_image, pj_slice, true_level,
                     get_x_y, get_x_y_from_0, mask_percentage, open_image)
 
 
@@ -307,6 +307,7 @@ def patch_sampling(slide, seed=None, mask_level=None,
 
     wsi_tissue = get_whole_image(slide, level=mask_level, numpy=True)
     wsi_mask = mask_function(wsi_tissue)
+    mask_level = true_level(slide, level = mask_level)
 
     if sampling_method == 'grid':  # grid is just grid_etienne with marge = 0
         min_row, min_col, max_row, max_col = 0, 0, *wsi_mask.shape

--- a/useful_wsi/utils.py
+++ b/useful_wsi/utils.py
@@ -54,6 +54,28 @@ def get_image(slide, para, numpy=True):
         slide = np.array(slide)[:, :, 0:3]
     return slide
 
+def true_level(slide, level):
+    """" Finds the true level to which the mask has been done.
+    In the case where the image does not have enough levels, get_whole_images() takes 
+    the level ${slide.level_count - 1} as default level. This function is there to actualize the value of level
+    so that the following treatement of the WSI is coherent with level = slide.level_count - 1.
+    
+    Parameters
+    ----------
+    slide : openslide image
+        WSI
+    level : int
+        asked level.
+    
+    Returns
+    -------
+    int
+        true level
+    """
+    max_level = slide.level_count - 1
+    level = min(max_level, level)
+    return level
+
 def get_whole_image(slide, level=None, numpy=True):
     """
     Return whole image at a certain level.


### PR DESCRIPTION
When the level of the mask is set to be greater than the number of
levels of the slide (max_level), then get_whole_image immediately adapt
the level to slide.level_count - 1. This commit updates level for the
rest of the procedure in Patch_sampling, otherwise we would get an
error.